### PR TITLE
Change list fetching to use the old, non-polymer UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,15 @@
       "integrity": "sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==",
       "dev": true
     },
+    "@types/cheerio": {
+      "version": "0.22.16",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.16.tgz",
+      "integrity": "sha512-bSbnU/D4yzFdzLpp3+rcDj0aQQMIRUBNJU7azPxdqMpnexjUSvGJyDuOBQBHeOZh1mMKgsJm6Dy+LLh80Ew4tQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.1.tgz",
@@ -25,8 +34,7 @@
     "@types/node": {
       "version": "11.13.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
-      "integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==",
-      "dev": true
+      "integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg=="
     },
     "@types/request": {
       "version": "2.48.4",
@@ -173,6 +181,11 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -250,6 +263,19 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      }
     },
     "chokidar": {
       "version": "3.3.0",
@@ -340,6 +366,22 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -392,6 +434,37 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -406,6 +479,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "es-abstract": {
       "version": "1.17.4",
@@ -620,6 +698,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -643,8 +734,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -890,6 +980,14 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -962,6 +1060,14 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1005,6 +1111,16 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -1151,6 +1267,14 @@
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1225,6 +1349,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   "author": "Daniel Leong",
   "license": "ISC",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.8"
   },
   "devDependencies": {
     "@types/chai": "^4.2.9",
+    "@types/cheerio": "^0.22.16",
     "@types/mocha": "^7.0.1",
     "@types/node": "^11.13.7",
     "@types/request-promise-native": "^1.0.17",

--- a/src/history.ts
+++ b/src/history.ts
@@ -4,12 +4,11 @@ import { ICreds } from "./creds";
 import {
     DelegateIterable,
     IIterableEntity,
-    IScrapingContinuation,
     isIterableEntity,
-    ScrapingIterableEntity,
 } from "./iterable";
+import { PolymerScrapingIterableEntity } from "./iterable/polymer";
 import { IVideo } from "./model";
-import { ISectionRenderer, pageTokenFromSectionRenderer, Scraper } from "./scraper";
+import { ISectionRenderer, pageTokenFromSectionRenderer, Scraper } from "./scraper/polymer";
 
 const HISTORY_URL = "https://www.youtube.com/feed/history";
 
@@ -27,7 +26,7 @@ function scrapeWatchHistory(sectionRenderer: ISectionRenderer) {
     return { items, nextPageToken };
 }
 
-class BaseWatchHistory extends ScrapingIterableEntity<IVideo> {
+class PolymerWatchHistory extends PolymerScrapingIterableEntity<IVideo> {
 
     constructor(creds: ICreds) {
         super(creds, HISTORY_URL, scrapeWatchHistory);
@@ -52,7 +51,7 @@ export class WatchHistory extends DelegateIterable<IVideo, WatchHistory> {
         super(
             isIterableEntity(credsOrBase)
                 ? credsOrBase
-                : new BaseWatchHistory(credsOrBase as ICreds),
+                : new PolymerWatchHistory(credsOrBase as ICreds),
             WatchHistory,
         );
     }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -1,5 +1,4 @@
 import { Credentials, ICreds } from "./creds";
-import { ISectionRenderer, Scraper } from "./scraper";
 
 export class OutOfBoundsError extends Error {
     constructor(message: string) {
@@ -61,6 +60,7 @@ export interface IIterableEntity<T, TSelf> extends AsyncIterable<T> {
 }
 
 export function isIterableEntity(v: any): v is IIterableEntity<any, any> {
+    if (!v) return false;
     return (v as any).findFirstMemberOf !== undefined;
 }
 
@@ -259,38 +259,6 @@ export abstract class AuthedIterableEntity<T> extends IterableEntity<T, string> 
 
         return super._doFetchNextPage();
     }
-}
-
-export interface IScrapingContinuation {
-    clickTracking: string;
-    continuation: string;
-}
-
-export abstract class ScrapingIterableEntity<T> extends IterableEntity<T, IScrapingContinuation> {
-
-    /** @internal */
-    public scraper: Scraper;
-
-    constructor(
-        creds: ICreds,
-        private url: string,
-        private scrapePage: (section: ISectionRenderer) => IPage<T, IScrapingContinuation>,
-    ) {
-        super();
-        this.scraper = new Scraper(creds);
-    }
-
-    protected async _fetchNextPage(pageToken: IScrapingContinuation | undefined) {
-        let section: ISectionRenderer;
-        if (!pageToken) {
-            section = await this.scraper.loadTabSectionRenderer(this.url);
-        } else {
-            section = await this.scraper.continueTabSectionRenderer(pageToken);
-        }
-
-        return this.scrapePage(section);
-    }
-
 }
 
 /**

--- a/src/iterable/angular.ts
+++ b/src/iterable/angular.ts
@@ -1,0 +1,39 @@
+import { ICreds } from "../creds";
+import { IPage, IterableEntity } from "../iterable";
+import { AngularScraper } from "../scraper/angular";
+
+export interface IAngularScrapingContinuation {
+    contentElement: string;
+    loadMoreUrl: string;
+    loadMoreWidgetId?: string;
+}
+
+export abstract class AngularScrapingIterableEntity<T> extends IterableEntity<T, IAngularScrapingContinuation> {
+
+    /** @internal */
+    public scraper: AngularScraper;
+
+    constructor(
+        creds: ICreds | undefined,
+        private url: string,
+        private scrapePage: ($: CheerioStatic) => IPage<T, IAngularScrapingContinuation>,
+    ) {
+        super();
+        this.scraper = new AngularScraper(creds);
+    }
+
+    protected async _fetchNextPage(pageToken: IAngularScrapingContinuation | undefined) {
+        if (!pageToken) {
+            const $ = await this.scraper.scrape(this.url);
+            return this.scrapePage($);
+        } else {
+            const $ = await this.scraper.scrapeContinuation(
+                "https://www.youtube.com" + pageToken.loadMoreUrl,
+                pageToken.contentElement,
+                pageToken.loadMoreWidgetId,
+            );
+            return this.scrapePage($);
+        }
+    }
+
+}

--- a/src/iterable/polymer.ts
+++ b/src/iterable/polymer.ts
@@ -1,0 +1,35 @@
+import { ICreds } from "../creds";
+import { IPage, IterableEntity } from "../iterable";
+import { ISectionRenderer, Scraper } from "../scraper/polymer";
+
+export interface IPolymerScrapingContinuation {
+    clickTracking: string;
+    continuation: string;
+}
+
+export abstract class PolymerScrapingIterableEntity<T> extends IterableEntity<T, IPolymerScrapingContinuation> {
+
+    /** @internal */
+    public scraper: Scraper;
+
+    constructor(
+        creds: ICreds | undefined,
+        private url: string,
+        private scrapePage: (section: ISectionRenderer) => IPage<T, IPolymerScrapingContinuation>,
+    ) {
+        super();
+        this.scraper = new Scraper(creds);
+    }
+
+    protected async _fetchNextPage(pageToken: IPolymerScrapingContinuation | undefined) {
+        let section: ISectionRenderer;
+        if (!pageToken) {
+            section = await this.scraper.loadTabSectionRenderer(this.url);
+        } else {
+            section = await this.scraper.continueTabSectionRenderer(pageToken);
+        }
+
+        return this.scrapePage(section);
+    }
+
+}

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -9,11 +9,16 @@ import {
     isIterableEntity,
     IterableEntity,
 } from "./iterable";
+import { AngularScrapingIterableEntity } from "./iterable/angular";
 import { PolymerScrapingIterableEntity } from "./iterable/polymer";
 import { IVideo } from "./model";
 import { ISectionRenderer, pageTokenFromSectionRenderer } from "./scraper/polymer";
 
 const PLAYLIST_URL = "https://www.youtube.com/playlist?list=%s";
+
+//
+// Polymer implementation
+//
 
 function scrapePlaylist(sectionRenderer: ISectionRenderer) {
     if (!sectionRenderer.contents.length) {
@@ -46,6 +51,54 @@ class PolymerYoutubePlaylist extends PolymerScrapingIterableEntity<IVideo> {
 
 }
 
+//
+// Angular implementation
+//
+
+function angularScrapePlaylist(
+    $: CheerioStatic,
+) {
+    const items: IVideo[] = $(".pl-video").map((_, element) => {
+        const el = $(element);
+        return {
+            desc: "",
+            id: el.attr("data-video-id"),
+            title: el.attr("data-title"),
+        };
+    }).get();
+
+    const loadMoreButton = $(".load-more-button");
+    const loadMoreUrl = loadMoreButton.attr("data-uix-load-more-href");
+    const loadMoreWidgetId = loadMoreButton.attr("data-uix-load-more-target-id");
+    const contentElement = loadMoreWidgetId
+        ? $("#" + loadMoreWidgetId).parent().prop("tagName")
+        : "div";
+
+    const nextPageToken = loadMoreUrl
+        ? { loadMoreUrl, loadMoreWidgetId, contentElement }
+        : undefined;
+
+    return {
+        items,
+        nextPageToken,
+    };
+}
+
+class AngularYoutubePlaylist extends AngularScrapingIterableEntity<IVideo> {
+
+    constructor(
+        creds: ICreds | undefined,
+        public readonly id: string,
+    ) {
+        super(creds, PLAYLIST_URL.replace("%s", id), angularScrapePlaylist);
+    }
+
+}
+
+//
+// Public, exported implementation
+//
+
 export class YoutubePlaylist extends DelegateIterable<IVideo, YoutubePlaylist> {
 
     constructor(id: string);
@@ -65,10 +118,10 @@ export class YoutubePlaylist extends DelegateIterable<IVideo, YoutubePlaylist> {
     ) {
         super(
             typeof credsOrBaseOrId === "string"
-                ? new PolymerYoutubePlaylist(undefined, credsOrBaseOrId)
+                ? new AngularYoutubePlaylist(undefined, credsOrBaseOrId)
                 : isIterableEntity(credsOrBaseOrId)
                     ? credsOrBaseOrId
-                    : new PolymerYoutubePlaylist(credsOrBaseOrId as ICreds, id!),
+                    : new AngularYoutubePlaylist(credsOrBaseOrId as ICreds, id!),
             YoutubePlaylist,
         );
     }

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -67,21 +67,7 @@ function angularScrapePlaylist(
         };
     }).get();
 
-    const loadMoreButton = $(".load-more-button");
-    const loadMoreUrl = loadMoreButton.attr("data-uix-load-more-href");
-    const loadMoreWidgetId = loadMoreButton.attr("data-uix-load-more-target-id");
-    const contentElement = loadMoreWidgetId
-        ? $("#" + loadMoreWidgetId).parent().prop("tagName")
-        : "div";
-
-    const nextPageToken = loadMoreUrl
-        ? { loadMoreUrl, loadMoreWidgetId, contentElement }
-        : undefined;
-
-    return {
-        items,
-        nextPageToken,
-    };
+    return { items };
 }
 
 class AngularYoutubePlaylist extends AngularScrapingIterableEntity<IVideo> {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -8,10 +8,10 @@ import {
     IIterableEntity,
     isIterableEntity,
     IterableEntity,
-    ScrapingIterableEntity,
 } from "./iterable";
+import { PolymerScrapingIterableEntity } from "./iterable/polymer";
 import { IVideo } from "./model";
-import { ISectionRenderer, pageTokenFromSectionRenderer } from "./scraper";
+import { ISectionRenderer, pageTokenFromSectionRenderer } from "./scraper/polymer";
 
 const PLAYLIST_URL = "https://www.youtube.com/playlist?list=%s";
 
@@ -35,10 +35,10 @@ function scrapePlaylist(sectionRenderer: ISectionRenderer) {
     return { items, nextPageToken };
 }
 
-class BaseYoutubePlaylist extends ScrapingIterableEntity<IVideo> {
+class PolymerYoutubePlaylist extends PolymerScrapingIterableEntity<IVideo> {
 
     constructor(
-        creds: ICreds,
+        creds: ICreds | undefined,
         public readonly id: string,
     ) {
         super(creds, PLAYLIST_URL.replace("%s", id), scrapePlaylist);
@@ -48,23 +48,27 @@ class BaseYoutubePlaylist extends ScrapingIterableEntity<IVideo> {
 
 export class YoutubePlaylist extends DelegateIterable<IVideo, YoutubePlaylist> {
 
+    constructor(id: string);
     constructor(
         creds: ICreds,
         id: string,
     );
 
     /** @internal Delegate factory */
+    // tslint:disable-next-line unified-signatures
     constructor(base: IIterableEntity<IVideo, any>);
 
     /** @internal actual constructor */
     constructor(
-        credsOrBase: ICreds | IIterableEntity<IVideo, any>,
+        credsOrBaseOrId: ICreds | IIterableEntity<IVideo, any> | string,
         id?: string,
     ) {
         super(
-            isIterableEntity(credsOrBase)
-                ? credsOrBase
-                : new BaseYoutubePlaylist(credsOrBase as ICreds, id!),
+            typeof credsOrBaseOrId === "string"
+                ? new PolymerYoutubePlaylist(undefined, credsOrBaseOrId)
+                : isIterableEntity(credsOrBaseOrId)
+                    ? credsOrBaseOrId
+                    : new PolymerYoutubePlaylist(credsOrBaseOrId as ICreds, id!),
             YoutubePlaylist,
         );
     }

--- a/src/scraper/angular.ts
+++ b/src/scraper/angular.ts
@@ -1,0 +1,123 @@
+import cheerio from "cheerio";
+import request from "request-promise-native";
+
+import { ICreds } from "../creds";
+
+// tslint:disable-next-line max-line-length
+const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36";
+
+export class AngularScraper {
+
+    private identityToken: string | undefined;
+    private xsrfToken: string | undefined;
+
+    private cookies: string | undefined;
+
+    constructor(
+        private creds?: ICreds,
+    ) {}
+
+    public async scrape(url: string) {
+        const html = await this.fetch(url);
+
+        return cheerio.load(html);
+    }
+
+    public async scrapeContinuation(
+        url: string,
+        contentElement: string,
+        contentId?: string,
+    ) {
+        const raw = await this.fetch(url);
+        const json = JSON.parse(raw);
+        const { content_html, load_more_widget_html } = json;
+        const html = `
+            <div>
+            <${contentElement} class="content" id="${contentId}">
+                ${content_html}
+            </${contentElement}>
+            ${load_more_widget_html}
+            </div>
+        `;
+
+        return cheerio.load(html);
+    }
+
+    private async fetch(url: string) {
+        const headers: any = {
+            "User-Agent": USER_AGENT,
+        };
+
+        const cookies = await this.getCookies();
+        if (cookies) {
+            headers.Cookie = cookies;
+        }
+
+        return request.get({
+            headers,
+            url,
+
+            qs: {
+                disable_polymer: "true",
+            },
+        });
+    }
+
+    // private async scrapeJson(url: string) {
+    //     const headers: any = {
+    //         "User-Agent": USER_AGENT,
+    //     };
+    //
+    //     const cookies = await this.getCookies();
+    //     if (cookies) {
+    //         headers.Cookie = cookies;
+    //     }
+    //
+    //     const html = await request.get({
+    //         headers,
+    //         url,
+    //     });
+    //
+    //     this.identityToken = extractIdentityToken(html) || this.identityToken;
+    //     this.xsrfToken = extractXsrfToken(html) || this.xsrfToken;
+    //     return extractJSON(html);
+    // }
+    //
+    // private async loadJson(url: string, opts?: {qs?: {}, form?: {}}) {
+    //     const { form, qs } = opts || { qs: undefined, form: undefined };
+    //     const fullJson = await request({
+    //         form,
+    //         headers: {
+    //             "Cookie": await this.getCookies(),
+    //             "User-Agent": USER_AGENT,
+    //             "X-Youtube-Client-Name": 1,
+    //             "X-Youtube-Client-Version": "2.20190321",
+    //             "X-Youtube-Identity-Token": this.identityToken,
+    //         },
+    //         json: true,
+    //         method: form === undefined ? "GET" : "POST",
+    //         qs,
+    //         url,
+    //     });
+    //
+    //     if (fullJson.reload === "now") {
+    //         return this.scrapeJson(url);
+    //     }
+    //
+    //     return fullJson[1].response;
+    // }
+
+    private async getCookies() {
+        if (this.cookies) return this.cookies;
+
+        if (this.creds instanceof Promise) {
+            const creds = await this.creds;
+            this.cookies = creds.cookies;
+            return creds.cookies;
+        }
+
+        if (this.creds) {
+            return this.creds.cookies;
+        }
+    }
+}

--- a/src/scraper/polymer.ts
+++ b/src/scraper/polymer.ts
@@ -1,9 +1,5 @@
 import request from "request-promise-native";
 
-// tslint:disable no-var-requires  STOPSHIP
-const debug: any = require("request-debug");
-debug(request);
-
 import { ICreds } from "../creds";
 import { IPolymerScrapingContinuation } from "../iterable/polymer";
 

--- a/src/scraper/polymer.ts
+++ b/src/scraper/polymer.ts
@@ -1,7 +1,11 @@
 import request from "request-promise-native";
 
-import { ICreds } from "./creds";
-import { IScrapingContinuation } from "./iterable";
+// tslint:disable no-var-requires  STOPSHIP
+const debug: any = require("request-debug");
+debug(request);
+
+import { ICreds } from "../creds";
+import { IPolymerScrapingContinuation } from "../iterable/polymer";
 
 // using this agent triggers Google to return some JSON we can consume
 // tslint:disable-next-line max-line-length
@@ -9,10 +13,13 @@ const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/
 
 const CONTINUATION_URL = "https://www.youtube.com/browse_ajax";
 
+import fs from "fs";
+
 function extractJSON(html: string) {
     const result = html.match(/window\["ytInitialData"\] = (\{.+\});$/m);
     if (!result) {
         // save so we can test
+        fs.writeFileSync("out.html", html);
         throw new Error("No match; format must have changed?");
     }
 
@@ -99,7 +106,7 @@ export class Scraper {
         }
     }
 
-    public async continueTabSectionRenderer(token: IScrapingContinuation) {
+    public async continueTabSectionRenderer(token: IPolymerScrapingContinuation) {
         const json = await this.loadJson(CONTINUATION_URL, {
             form: {
                 session_token: this.xsrfToken,
@@ -129,11 +136,21 @@ export class Scraper {
     }
 
     private async scrapeJson(url: string) {
+        const headers: any = {
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+            "Host": "www.youtube.com",
+            "User-Agent": USER_AGENT,
+        };
+
+        const cookies = await this.getCookies();
+        if (cookies) {
+            headers.Cookie = cookies;
+        }
+
         const html = await request.get({
-            headers: {
-                "Cookie": await this.getCookies(),
-                "User-Agent": USER_AGENT,
-            },
+            headers,
             url,
         });
 


### PR DESCRIPTION
This is how `youtube-dl` works, and seems to be more reliable. The version our old code depends on still gets served, but I can't seem to trigger it from this library. Scrapers for the polymer UI are left in for reference, and in case the polymer-disabled UI ever gets removed.